### PR TITLE
Use noglob for both official names

### DIFF
--- a/calc.plugin.zsh
+++ b/calc.plugin.zsh
@@ -1,6 +1,7 @@
 
 autoload -U zcalc
-function = {
+function __calc_plugin {
     zcalc -e "$*"
 }
-aliases[calc]='noglob ='
+aliases[calc]='noglob __calc_plugin'
+aliases[=]='noglob __calc_plugin'


### PR DESCRIPTION
Otherwise things like this might fail or give false results:
`touch 1112; = 1*2`, while this works correctly: `touch 1112; calc 1*2`.