### PR TITLE
revise readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ antigen bundle arzzen/calc.plugin.zsh
 ### Usage
 ```bash
 # addition
-root@pc:~$ = 5+3                                                
+root@pc:~$ = 5+3
 8
 
 # multiplication
@@ -37,51 +37,47 @@ root@pc:~$ = -4-2
 -6
 
 # division
-root@pc:~$ = 4/2
-2.00000000000000000000
+root@pc:~$ = 5.0/2
+2.5
 
-# square root 
-root@pc:~$ = "scale=30; sqrt(2)"
-1.414213562373095048801688724209
-
-# power
-root@pc:~$ = "6^6"
-46656
+# square root
+root@pc:~$ = sqrt(2)
+1.41421
 
 # parentheses
-root@pc:~$ = "(6^6)^6"
-10314424798490535546171949056
+root@pc:~$ = "(6+6)*6"
+72
 
-# convert from decimal to hexadecimal 
-root@pc:~$ = "obase=16; 255"
-FF
+# convert from decimal to hexadecimal
+root@pc:~$ = "[#16] 255"
+16#FF
 
-# convert from decimal to binary 
-root@pc:~$ = "obase=2; 12"
-1100
+# convert from decimal to binary
+root@pc:~$ = "[#2] 12"
+2#1100
 
-# convert from binary to decimal 
-root@pc:~$ = "ibase=2; obase=A;1100"
+# convert from binary to decimal
+root@pc:~$ = "2#1100"
 12
 
-# convert from hexadecimal to decimal 
-root@pc:~$ = "ibase=16; obase=A;FF"
+# convert from hexadecimal to decimal
+root@pc:~$ = "16#FF"
 255
 
 # arctangent
-root@pc:~$ = "a(1)"
-.78539816339744830961
+root@pc:~$ = atan(1)
+.785398
 
 # PI value
-root@pc:~$ = "scale=10; 4*a(1)"
-3.1415926532
+root@pc:~$ = PI
+3.14159
 
 # more complex
-root@pc:~$ = "scale=2; 3.4+7/8-(5.94*(4*a(1)))"
--14.26
+root@pc:~$ = "scale=2; 3.4+7/8-(5.94*(4*atan(1)))"
+-15.2611
 ```
 
-### Plugin location 
+### Plugin location
 
 ```bash
 .oh-my-zsh


### PR DESCRIPTION
since this plugin use `zcalc`
some syntax is changed

this commit update the readme to align to the behaviour

and there's one more issue..
I can't found the syntax for power (`^` is for the xor operation now)