### PR TITLE
Use floating point by default

### DIFF
--- a/calc.plugin.zsh
+++ b/calc.plugin.zsh
@@ -1,7 +1,7 @@
 
 autoload -U zcalc
 function __calc_plugin {
-    zcalc -e "$*"
+    zcalc -f -e "$*"
 }
 aliases[calc]='noglob __calc_plugin'
 aliases[=]='noglob __calc_plugin'


### PR DESCRIPTION
So `= 3/4` evaluates to `0.75` and not `0`.

Downside is that any integer answer will now have a trailing `.`.